### PR TITLE
Small improvements after making git prefix optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 ## Oh-My-Zsh Sorin for Fish!
 "Opinionated" (lazy) port of the Oh-My-Zsh "Sorin" theme for the Fish Shell. 
 
-![default prompt](https://raw.githubusercontent.com/LastContinue/snorin/assets/default.png)
+<img src="https://raw.githubusercontent.com/LastContinue/snorin/assets/default.png" alt="default prompt" width=80% height=80%>
 
 ## What? Why? Isn't there already a Sorin theme for Fish?
 Yes, in fact, there are two just in the main Fish repo alone (and probably an untold amount in the wild!) 
 
-However, I found the one in `fish_config` to be lacking some features (Git), and [the second one](https://github.com/fish-shell/fish-shell/blob/988283c7177d8496f18c1fea1a1007aa8d45d984/share/tools/web_config/sample_prompts/sorin.fish) too complex to understand what was happending (especially when compairing the source for the [oh-my-zsh original](https://github.com/robbyrussell/oh-my-zsh/blob/master/themes/sorin.zsh-theme)), so I started hacking.
-
+However, I found the one in `fish_config` to be lacking some features (Git), and [the second one](https://github.com/fish-shell/fish-shell/blob/master/share/tools/web_config/sample_prompts/sorin.fish) was too different from the Sorin theme I liked from [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh/blob/master/themes/sorin.zsh-theme). So, I started hacking  
 ## Installation
 
 Fisher
@@ -22,16 +21,18 @@ omf install https://github.com/lastcontinue/snorin
 ```
 
 ## Features
-Puts the Git repo info on the left, on the right it shows Git status
-![git repo info](https://raw.githubusercontent.com/LastContinue/snorin/assets/git_stuff1.png)
-![more git repo info](https://raw.githubusercontent.com/LastContinue/snorin/assets/git_stuff2.png)
+Puts the Git repo info on the left, on the right it shows Git status  
+<img src="https://raw.githubusercontent.com/LastContinue/snorin/assets/git_stuff1.png" alt="git repo info" width=90% height=90%>  
+It can do branches and hashes  
+<img src="https://raw.githubusercontent.com/LastContinue/snorin/assets/git_stuff2.png" alt="more git repo info" width=40% height=40%>
 
-* new files `★` (the current star is _slightly_ different than the screenshot above. I will update screenshots when I get some time)
-* modified files `✹`
-* removed files `✖`
-* staged files `✚`
-* file renamed (might not show up until you stage) `➜` 
-* unmerged (usually shows up during merge conflict) `═`
+#### Symbols<sup id="a1">[[1]](#f1)</sup>
+* new (untracked) files - cyan `★` 
+* modified files - blue `✹`
+* removed files - red `✖`
+* staged files - green `✚`
+* file renamed - magenta `➜` (using `git mv` will trigger this. Just doing `mv foo bar` might not do it) 
+* unmerged - yellow `═` (usually shows up during merge conflict)  
 
 ### Variable support  
 This theme includes support for its own optional variables if you want to further customize your experience (without writing any code). 
@@ -41,64 +42,61 @@ This theme includes support for its own optional variables if you want to furthe
 * `snorin_show_error_code`
 
 #### Chevrons
-`snorin_chevrons`  
-![chevron example](https://raw.githubusercontent.com/LastContinue/snorin/assets/chevrons.png)
-
+<img src="https://raw.githubusercontent.com/LastContinue/snorin/assets/chevrons.png" alt="chevron example" width=50% height=50%>  
 
 by default, this prompt will give you one green ❯ symbol (this is how the Oh-My-Zsh Sorin does it)  
 However, the "Sorin" themes for Fish usually have three: a red ❯, a yellow ❯, and a green ❯ (something like `❯❯❯`) .  
 
-I decided to let the user chose.  
+I decided to let the user choose!  
 You can have as many ❯ 's as you want with this theme by setting  
 
 `set snorin_chevrons color1 color2 color3 .. color n`  
 
-For example, I like the red, yellow, green, so I have mine set as  
+For example, If you wanted `red, yellow, green` you could do
 
 `set -U snorin_chevrons red yellow green` or  
-`set -gx snorin_chevrons red yellow green` if you're writing this to a config
+`set -g snorin_chevrons red yellow green` if you're writing this to a config  
 
 #### Git Prefix
-`snorin_show_git_prefix`
+<img src="https://raw.githubusercontent.com/LastContinue/snorin/assets/git_prefix.png" alt="git prefix example" width=50% height=50%>
 
-I realized that after _months_ of daily use, the `git:` prefix before the branch was a bit redundant. If this theme could support multiple DVCS, then having a prefix for the type would make sense (`svn:`, `hg:`, `git:`, etc).  I decided to **disable the prefix by default** in order to cut down on visual clutter (Apologies that the screenshots don't reflect this for now - I plan to make new screenshots soon 🙇‍♂️). I am aware that Fish includes a very similar variable by default, and that you could also use `fish_vcs_prompt` if you wanted other vcs types, but this is _lazy_ port after all 😉
+[My inspiration Sorin theme](https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/sorin.zsh-theme#L29) uses `git:` as a prefix for the branch/hash information. However, after _months_ of daily use, I started to feel this might be a bit redundant. If this theme could support multiple DVCS, then having a prefix for the type would make more sense (`svn:`, `hg:`, `git:`, etc).  I decided to **disable the prefix by default** in order to cut down on visual clutter. I am aware that Fish includes a very similar variable by default, and that you could also use `fish_vcs_prompt` if you wanted other vcs types, but this is _lazy_ port after all 😉  
 
+`set -U snorin_show_git_prefix` or  
+`set -g snorin_show_git_prefix` if you're writing this to a config file  
+(no value needs to be set)  
 
-`set -U snorin_show_git_prefix` will enable the `git:` prefix (it doesn't need a value, only to be set. Use `set -gx snorin_show_git_prefix` if you're writing this to a config file)
 `set -e snorin_show_git_prefix` will disable the `git:` prefix **this is the default behavior**
 
 #### Error Codes
-`snorin_show_error_code`  
+<img src="https://raw.githubusercontent.com/LastContinue/snorin/assets/error_codes.png" alt="git prefix example" width=90% height=90%>
 
-By default, my inspiration Sorin theme uses a red `⏎` on the right side to indicate the last line returned non-zero. However, after playing around with some commands (`set -q` comes to mind), I realized _sometimes_ it might be better for it to actually print out the eror code instead.  
+By default, [my inspiration Sorin theme](https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/sorin.zsh-theme#L25) uses a red `⏎` on the right side to indicate the last line returned non-zero. However, after playing around with some commands (`set -q` comes to mind), I realized _sometimes_ it might be better for it to actually print out the error code instead. (Additionally the `⏎` can be a bit hard to read...)  
 
-This can now be enabled via  
-`set -U snorin_show_error_code` or
-`set -gx snorin_show_error_code` if you're writing to this to a config
+`set -U snorin_show_error_code` or  
+`set -g snorin_show_error_code` if you're writing to this to a config  
 
 `set -e snorin_show_git_prefix` will disable it and you'll return to the `⏎` **this is the default behavior**
 
 ### Random Fun
 I thought it might be fun to have the ability to have random colors generated for your prompts, so I wrote a little function that uses 
-either `jot` or `shuf` (make sure you have at least one of these installed<sup id="a1">[1](#f1)</sup>) to help make some random colors for your prompts. It works like 
+either `jot` or `shuf` (make sure you have at least one of these installed<sup id="a2">[[2]](#f2)</sup>) to help make some random colors for your prompts. It works like 
 this  
 ```
 snorin_random_chevrons N
 ```
-(where N is the number of chevrons you want. It can also be passed without N to just do one chevron)
+(where N is the number of chevrons you want. It can also be passed without N to just do one random colored chevron)
 
 #### For Instance
-If you want each new term session/tab to have a different prompt in your `fish_config` (mine's at `~/.config/fish/config.fish`, but ymmv) you could do something like  
+If you want each new term session/tab to have a different prompt<sup id="a3">[[3]](#f3)</sup> in your `fish_config` (mine's at `~/.config/fish/config.fish`, but ymmv) you could do something like  
 ```
 if type -q snorin_random_chevrons
     snorin_random_chevrons 3
 end
 ```  
-(`type -q` will (q)uietly check if a function/program if it exists, returning a value rather than listing the output of `type`)
-
 That should give each new session/tab a different set of colors (maybe. I only defined 10 colors so duplicates will happen)
 
-This is just a "for instance". There's hundreds of triggering events you could use to have a prompt
+This is just a "for instance". There are hundreds of triggering events you could use to have a prompt
 change colors or number of `❯`. Use your imagination!
 
 **sources**:  
@@ -107,4 +105,8 @@ https://github.com/fish-shell/fish-shell/pull/2243
 (I believe this eventually morphed into [this](https://github.com/fish-shell/fish-shell/blob/master/share/tools/web_config/sample_prompts/sorin.fish), however I found this shorter version better as inpiration)
 
 **Footnotes**  
-<b id="f1">1</b> Interestingly enough, `shuf` doesn't do duplicates, whereas `jot` does. I don't consider this an issue, but this might drive some people _crazy_ [↩](#a2)
+<b id="f1">1.</b> What each one of these colors looks like _exactly_ depends on how you've setup your colors in Fish or in your terminal. My magenta is set to `#a665a5`, yours maybe something different.[↩](#a1)
+
+<b id="f2">2.</b> Interestingly enough, `shuf` doesn't do duplicates, whereas `jot` does. I don't consider this an issue, but this might drive some people _crazy_.[↩](#a2)
+
+<b id="f3">3.</b> You may have noticed that I used this when making most of the screenshots. I like it 😁[↩](#a3)

--- a/README.md
+++ b/README.md
@@ -32,12 +32,18 @@ Puts the Git repo info on the left, on the right it shows Git status
 * staged files `✚`
 * file renamed (might not show up until you stage) `➜` 
 * unmerged (usually shows up during merge conflict) `═`
-* mystery condition (_something_ happened<sup id="a1">[1](#f1)</sup>) `◊`  
 
 ### Variable support  
+This theme includes support for its own optional variables if you want to further customize your experience (without writing any code). 
+
+* `snorin_chevrons [color1 .. colorN]`
+* `snorin_show_git_prefix`
+* `snorin_show_error_code`
+
+#### Chevrons
+`snorin_chevrons`  
 ![chevron example](https://raw.githubusercontent.com/LastContinue/snorin/assets/chevrons.png)
 
-`snorin_chevrons`  
 
 by default, this prompt will give you one green ❯ symbol (this is how the Oh-My-Zsh Sorin does it)  
 However, the "Sorin" themes for Fish usually have three: a red ❯, a yellow ❯, and a green ❯ (something like `❯❯❯`) .  
@@ -49,20 +55,32 @@ You can have as many ❯ 's as you want with this theme by setting
 
 For example, I like the red, yellow, green, so I have mine set as  
 
-`set -U snorin_chevrons red yellow green`
+`set -U snorin_chevrons red yellow green` or  
+`set -gx snorin_chevrons red yellow green` if you're writing this to a config
 
----
+#### Git Prefix
 `snorin_show_git_prefix`
 
-I realized that after _months_ of daily use, the `git:` prefix before the branch was a bit redundant. If this theme could support multiple DVCS, then having a prefix for the type would make sense (`svn:`, `hg:`, `git:`, etc).  I decided to **disable the prefix by default** in order to cut down on visual clutter (Apologies that the screenshots don't reflect this for now - I plan to make new screenshots soon 🙇‍♂️)  
+I realized that after _months_ of daily use, the `git:` prefix before the branch was a bit redundant. If this theme could support multiple DVCS, then having a prefix for the type would make sense (`svn:`, `hg:`, `git:`, etc).  I decided to **disable the prefix by default** in order to cut down on visual clutter (Apologies that the screenshots don't reflect this for now - I plan to make new screenshots soon 🙇‍♂️). I am aware that Fish includes a very similar variable by default, and that you could also use `fish_vcs_prompt` if you wanted other vcs types, but this is _lazy_ port after all 😉
 
 
-`set -U snorin_show_git_prefix` will enable the `git:` prefix (it doesn't need a value, only to be set)  
+`set -U snorin_show_git_prefix` will enable the `git:` prefix (it doesn't need a value, only to be set. Use `set -gx snorin_show_git_prefix` if you're writing this to a config file)
 `set -e snorin_show_git_prefix` will disable the `git:` prefix **this is the default behavior**
+
+#### Error Codes
+`snorin_show_error_code`  
+
+By default, my inspiration Sorin theme uses a red `⏎` on the right side to indicate the last line returned non-zero. However, after playing around with some commands (`set -q` comes to mind), I realized _sometimes_ it might be better for it to actually print out the eror code instead.  
+
+This can now be enabled via  
+`set -U snorin_show_error_code` or
+`set -gx snorin_show_error_code` if you're writing to this to a config
+
+`set -e snorin_show_git_prefix` will disable it and you'll return to the `⏎` **this is the default behavior**
 
 ### Random Fun
 I thought it might be fun to have the ability to have random colors generated for your prompts, so I wrote a little function that uses 
-either `jot` or `shuf` (make sure you have at least one of these installed<sup id="a2">[2](#f2)</sup>) to help make some random colors for your prompts. It works like 
+either `jot` or `shuf` (make sure you have at least one of these installed<sup id="a1">[1](#f1)</sup>) to help make some random colors for your prompts. It works like 
 this  
 ```
 snorin_random_chevrons N
@@ -86,9 +104,7 @@ change colors or number of `❯`. Use your imagination!
 **sources**:  
 https://github.com/robbyrussell/oh-my-zsh/blob/master/themes/sorin.zsh-theme  
 https://github.com/fish-shell/fish-shell/pull/2243  
-(I believe this eventually morphed into [this](https://github.com/fish-shell/fish-shell/blob/988283c7177d8496f18c1fea1a1007aa8d45d984/share/tools/web_config/sample_prompts/sorin.fish), however I found this shorter version better as inpiration)
+(I believe this eventually morphed into [this](https://github.com/fish-shell/fish-shell/blob/master/share/tools/web_config/sample_prompts/sorin.fish), however I found this shorter version better as inpiration)
 
 **Footnotes**  
-<b id="f1">1</b> Based on https://git-scm.com/docs/git-status there's are quite a few cases I didn't code for because I don't come across them very often. I figured `◊` looked innocent enough. If you come across this a lot, please help me out and file an issue with details or make a PR yourself 🙇‍♂️ [↩](#a1)
-
-<b id="f2">2</b> Interestingly enough, `shuf` doesn't do duplicates, whereas `jot` does. I don't consider this an issue, but this might drive some people _crazy_ [↩](#a2)
+<b id="f1">1</b> Interestingly enough, `shuf` doesn't do duplicates, whereas `jot` does. I don't consider this an issue, but this might drive some people _crazy_ [↩](#a2)

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -25,7 +25,7 @@ function fish_prompt -d "Snorin - oh-my-zsh sorin inspired prompt"
     end
 
     # print fun part of prompt
-    test -n "$snorin_chevrons"; or set -gx snorin_chevrons green
+    test -n "$snorin_chevrons"; or set -g snorin_chevrons green
 
     for chevron_color in $snorin_chevrons
         print_color $chevron_color ❯

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1,27 +1,27 @@
 function fish_prompt -d "Snorin - oh-my-zsh sorin inspired prompt"
-    #Main
-	printf (set_color cyan)(prompt_pwd)' '
+    # where are we ?
+	printf (set_color cyan)(prompt_pwd)" "
 
-    #determine if git repo is set...
+    # determine if git repo is set...
 	if git rev-parse ^ /dev/null
         set git_status (git branch --show-current)
         test -n "$git_status"; or set -l git_status (git rev-parse --short HEAD)
 
-        #optionally show "git:" in front of branch/revision
+        # optionally show "git:" in front of branch/revision
         set -q snorin_show_git_prefix
-        and set -l git_prefix (set_color blue)git(set_color brwhite):
-        or set git_prefix ''
+        and set git_prefix (set_color blue)git(set_color brwhite):
+        or set git_prefix ""
 
-        printf $git_prefix(set_color red)$git_status' '
+        printf $git_prefix(set_color red)$git_status" "
     end
 
-    #print fun part of prompt
-    set chevron '❯'
-    test -n "$snorin_chevrons"; or set -U snorin_chevrons green
+    # print fun part of prompt
+    set chevron "❯"
+    test -n "$snorin_chevrons"; or set -g snorin_chevrons green
 
     for chevron_color in $snorin_chevrons
         printf (set_color $chevron_color)$chevron
     end
-    printf ' '
+    printf " "
     set_color normal
 end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -2,17 +2,15 @@ function fish_prompt -d "Snorin - oh-my-zsh sorin inspired prompt"
     # where are we ?
 	printf (set_color cyan)(prompt_pwd)" "
 
-    # determine if git repo is set...
-	if git rev-parse ^ /dev/null
-        set git_status (git branch --show-current)
-        test -n "$git_status"; or set -l git_status (git rev-parse --short HEAD)
-
+    # determine if git repo is set and try to set some information 
+	if set git_info (git symbolic-ref --short HEAD ^ /dev/null) # try set branch name
+    or set git_info (git rev-parse --short HEAD ^ /dev/null) # else try to set hash
         # optionally show "git:" in front of branch/revision
         set -q snorin_show_git_prefix
         and set git_prefix (set_color blue)git(set_color brwhite):
         or set git_prefix ""
 
-        printf $git_prefix(set_color red)$git_status" "
+        printf $git_prefix(set_color red)$git_info" "
     end
 
     # print fun part of prompt

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -4,19 +4,19 @@ function fish_prompt -d "Snorin - oh-my-zsh sorin inspired prompt"
 
     #determine if git repo is set...
 	if git rev-parse ^ /dev/null
-        set -l git_status (git branch --show-current)
+        set git_status (git branch --show-current)
         test -n "$git_status"; or set -l git_status (git rev-parse --short HEAD)
 
         #optionally show "git:" in front of branch/revision
         set -q snorin_show_git_prefix
         and set -l git_prefix (set_color blue)git(set_color brwhite):
-        or set -l git_prefix ''
+        or set git_prefix ''
 
         printf $git_prefix(set_color red)$git_status' '
     end
 
     #print fun part of prompt
-    set -l chevron '❯'
+    set chevron '❯'
     test -n "$snorin_chevrons"; or set -U snorin_chevrons green
 
     for chevron_color in $snorin_chevrons

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1,25 +1,34 @@
 function fish_prompt -d "Snorin - oh-my-zsh sorin inspired prompt"
+	# use these to DRY up some code
+	function print_color_space
+        printf '%s ' (set_color $argv[1])$argv[2]
+        set_color normal
+	end
+
+	function print_color
+        printf '%s' (set_color $argv[1])$argv[2]
+        set_color normal
+	end
+
     # where are we ?
-	printf (set_color cyan)(prompt_pwd)" "
+	print_color_space cyan (prompt_pwd)
 
     # determine if git repo is set and try to set some information 
-	if set git_info (git symbolic-ref --short HEAD ^ /dev/null) # try set branch name
-    or set git_info (git rev-parse --short HEAD ^ /dev/null) # else try to set hash
+	if set -l repo_info (command git symbolic-ref --short HEAD ^ /dev/null) # try set branch name
+    or set -l repo_info (command git rev-parse --short HEAD ^ /dev/null) # else try to set hash
         # optionally show "git:" in front of branch/revision
-        set -q snorin_show_git_prefix
-        and set git_prefix (set_color blue)git(set_color brwhite):
-        or set git_prefix ""
+        # I believe there's a built-in Fish variable for this functionality.
+        # May move to that in the future if it works roughly the same
+        set -q snorin_show_git_prefix; and print_color blue "git"; and print_color brwhite ":"
 
-        printf $git_prefix(set_color red)$git_info" "
+        print_color_space red $repo_info
     end
 
     # print fun part of prompt
-    set chevron "❯"
-    test -n "$snorin_chevrons"; or set -g snorin_chevrons green
+    test -n "$snorin_chevrons"; or set -gx snorin_chevrons green
 
     for chevron_color in $snorin_chevrons
-        printf (set_color $chevron_color)$chevron
+        print_color $chevron_color ❯
     end
-    printf " "
-    set_color normal
+    printf " " 
 end

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -1,4 +1,5 @@
 function fish_right_prompt -d "Snorin - oh-my-zsh sorin inspired prompt - right side"
+    set -l last_status $status
 
 	# use this to DRY up some code
 	function print_symbol
@@ -7,7 +8,10 @@ function fish_right_prompt -d "Snorin - oh-my-zsh sorin inspired prompt - right 
 	end
 
     # last status
-    test $status != 0; and printf (set_color red)"⏎ "
+    if not test $last_status -eq 0
+        printf (set_color red)"⏎ "
+        set_color normal
+    end
 
 	if git rev-parse ^ /dev/null
 		for i in (git status -s | cut -c 1-2 | string trim | sort | uniq)
@@ -18,24 +22,23 @@ function fish_right_prompt -d "Snorin - oh-my-zsh sorin inspired prompt - right 
                 # in "normal" usage, as well as trying to keep close
                 # to the oh-my-zsh source
                 # Always double-check your Git status before commiting
-                case "A*"
+                case A AM
                     print_symbol green ✚
-                case "D*"
+                case D AD MD RD
                     print_symbol red ✖
-                case "M*"
+                case M MM
                     print_symbol blue ✹
-                case "R*"
+                case R RM
                     print_symbol magenta ➜
-                case "*U*"
+                case "*U*" AA
                     print_symbol yellow ═
-                # this is usually a new file... usually
-                case "\?\?"
+                case \?\?
                     print_symbol cyan ★
                 case "*"
                     print_symbol yellow ◊
-                    #if you start getting this a lot,
-                    #please open an issue or file a PR
-                    #I wanted something generic that didn't really mean "good" or "bad"
+                    # if you start getting this a lot,
+                    # please open an issue or file a PR
+                    # I wanted something generic that didn't really mean "good" or "bad"
             end
 		end
 	end

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -10,14 +10,7 @@ function fish_right_prompt -d "Snorin - oh-my-zsh sorin inspired prompt - right 
     test $status != 0; and printf (set_color red)"⏎ "
 
 	if git rev-parse ^ /dev/null
-        #take advantage of Fish `String` commands
-		for i in (git status --porcelain |
-                    cut -c 1-2 |
-                    string trim |
-                    string replace "AM" "A" |
-                    string replace "MM" "M" |
-                    sort |
-                    uniq)
+		for i in (git status -s | cut -c 1-2 | string trim | sort | uniq)
 			switch $i
                 # There's quite a few cases missing according to
                 # https://git-scm.com/docs/git-status
@@ -25,20 +18,15 @@ function fish_right_prompt -d "Snorin - oh-my-zsh sorin inspired prompt - right 
                 # in "normal" usage, as well as trying to keep close
                 # to the oh-my-zsh source
                 # Always double-check your Git status before commiting
-                case "AD"
-                    #this can happen if you add a file, then delete it after staging the change
-                    #IMHO these two just cancel each other out
-                case "A"
+                case "A*"
                     print_symbol green ✚
-                case "D"
+                case "D*"
                     print_symbol red ✖
-                case "M"
+                case "M*"
                     print_symbol blue ✹
-                case "R"
-                case "RM"
+                case "R*"
                     print_symbol magenta ➜
-                case "DU"
-                case "UU"
+                case "*U*"
                     print_symbol yellow ═
                 # this is usually a new file... usually
                 case "\?\?"

--- a/snorin_random_chevrons.fish
+++ b/snorin_random_chevrons.fish
@@ -1,23 +1,23 @@
 function snorin_random_chevrons -d "randomly sets snorin_chevrons colors for N number of chevrons."
-    set possible_colors red yellow green blue cyan magenta white brred brmagenta brwhite
-    set shuffled_colors
-    set color_count $argv[1]
+    set -l possible_colors red yellow green blue cyan magenta white brred brmagenta brwhite
+    set -l color_count $argv[1]
     # default color_count to 1 if nothing was passed in
     test -n "$color_count"; or set color_count 1
     
     # If shuf is installed, use it. Doesn't do duplicates
     if type -q shuf
-        set shuffled_colors (shuf -i1-10 -n$color_count)
+        set shuffled_colors (command shuf -i1-10 -n$color_count)
     # jot is installed by default on MacOS so 'easy win' here. Occasionally does duplicates
     else if type -q jot
-        set shuffled_colors (jot -r $color_count 1 10)
+        set shuffled_colors (command jot -r $color_count 1 10)
     else
         echo "ERROR: either 'shuf' or 'jot' needs to be installed to use this function"
         return 1
     end
+    
     set color_list
     for c in $shuffled_colors
         set color_list $color_list $possible_colors[$c]
     end
-    set -g snorin_chevrons $color_list
+    set -gx snorin_chevrons $color_list
 end

--- a/snorin_random_chevrons.fish
+++ b/snorin_random_chevrons.fish
@@ -1,15 +1,14 @@
-#! /bin/env fish
 function snorin_random_chevrons -d "randomly sets snorin_chevrons colors for N number of chevrons."
     set possible_colors red yellow green blue cyan magenta white brred brmagenta brwhite
     set shuffled_colors
     set color_count $argv[1]
-    #default color_count to 1 if nothing was passed in
-    test -n "$color_count"; or set -l color_count 1
+    # default color_count to 1 if nothing was passed in
+    test -n "$color_count"; or set color_count 1
     
-    #If shuf is installed, use it. Doesn't do duplicates
+    # If shuf is installed, use it. Doesn't do duplicates
     if type -q shuf
         set shuffled_colors (shuf -i1-10 -n$color_count)
-    #jot is installed by default on MacOS so 'easy win' here. Occasionally does duplicates
+    # jot is installed by default on MacOS so 'easy win' here. Occasionally does duplicates
     else if type -q jot
         set shuffled_colors (jot -r $color_count 1 10)
     else
@@ -20,5 +19,5 @@ function snorin_random_chevrons -d "randomly sets snorin_chevrons colors for N n
     for c in $shuffled_colors
         set color_list $color_list $possible_colors[$c]
     end
-    set snorin_chevrons $color_list
+    set -g snorin_chevrons $color_list
 end

--- a/snorin_random_chevrons.fish
+++ b/snorin_random_chevrons.fish
@@ -19,5 +19,5 @@ function snorin_random_chevrons -d "randomly sets snorin_chevrons colors for N n
     for c in $shuffled_colors
         set color_list $color_list $possible_colors[$c]
     end
-    set -gx snorin_chevrons $color_list
+    set -g snorin_chevrons $color_list
 end

--- a/snorin_random_chevrons.fish
+++ b/snorin_random_chevrons.fish
@@ -1,8 +1,8 @@
 #! /bin/env fish
 function snorin_random_chevrons -d "randomly sets snorin_chevrons colors for N number of chevrons."
-    set -l possible_colors red yellow green blue cyan magenta white brred brmagenta brwhite
-    set -l shuffled_colors
-    set -l color_count $argv[1]
+    set possible_colors red yellow green blue cyan magenta white brred brmagenta brwhite
+    set shuffled_colors
+    set color_count $argv[1]
     #default color_count to 1 if nothing was passed in
     test -n "$color_count"; or set -l color_count 1
     
@@ -16,7 +16,7 @@ function snorin_random_chevrons -d "randomly sets snorin_chevrons colors for N n
         echo "ERROR: either 'shuf' or 'jot' needs to be installed to use this function"
         return 1
     end
-    set -l color_list
+    set color_list
     for c in $shuffled_colors
         set color_list $color_list $possible_colors[$c]
     end


### PR DESCRIPTION
After I made the `git:` prefix configurable by variable, I noticed _lots_ of small issues that could be improved upon. Also found some bugs when trying to make updated screenshots.
I figured I could document these changes better in PR format than just merging something into `main` and then putting comments on various lines. 

* `$status` indicator wasn't even working
    * Added an option to allow for actual status code to be displayed instead
* "R" and "RM" cases in Git weren't actually being indicated (purple arrow)
    * Ended up just completely redoing the status indicator logic
* Inconsistent/uneeded variable scopes (probably still not correct, but "more right")
* Inconsistent comment formatting
* Inconsistent quotes 
    * Ended up going with "" for stringy-strings `tell the user "this is broken" type stuff`
    * Ended up going with '' for "I just need a quote here" stuff. `printf '%s'`
    * The more I look at this, the more keep screwing around with it, so better just to "push it and move on"
* `set -U` probably shouldn't be used in plugin code
*  `snorin_random_chevrons` defaults to `1` if no arguments are passed 
    * `snorin_random_chevrons` and `snorin_random_chevons 1` are now the same thing
* Added new screenshots in README
    * Will ended up making at least two dozen commits fooling around with this. For some reason I can't seem to see typos and mistakes unless it's actually on Github 🙄 

If I end up making improvements and changes more regularly I might move to releases, but that seems like a hassle.