### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -14,8 +14,8 @@ function fish_prompt -d "Snorin - oh-my-zsh sorin inspired prompt"
 	print_color_space cyan (prompt_pwd)
 
     # determine if git repo is set and try to set some information 
-	if set -l repo_info (command git symbolic-ref --short HEAD ^ /dev/null) # try set branch name
-    or set -l repo_info (command git rev-parse --short HEAD ^ /dev/null) # else try to set hash
+	if set -l repo_info (command git symbolic-ref --short HEAD 2> /dev/null) # try set branch name
+    or set -l repo_info (command git rev-parse --short HEAD 2> /dev/null) # else try to set hash
         # optionally show "git:" in front of branch/revision
         # I believe there's a built-in Fish variable for this functionality.
         # May move to that in the future if it works roughly the same

--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -18,7 +18,7 @@ function fish_right_prompt -d "Snorin - oh-my-zsh sorin inspired prompt - right 
         end
     end
 
-	if command git rev-parse ^ /dev/null
+	if command git rev-parse 2> /dev/null
         # https://github.com/fish-shell/fish-shell/blob/master/share/tools/web_config/sample_prompts/sorin.fish#L110
         set -l git_status_code (command git status --porcelain | string sub -l2)
 


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^`
character has been disabled by default.

Ref [oh-my-fish/oh-my-fish#585][2]

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: oh-my-fish/oh-my-fish#585